### PR TITLE
Add opam-update to appveyor-opam.sh

### DIFF
--- a/appveyor-opam.sh
+++ b/appveyor-opam.sh
@@ -81,6 +81,7 @@ case "$SWITCH" in
         echo "ocamlc reports a dubious system: ${ocaml_system}. Good luck!" >&2
         eval $(opam config env)
 esac
+opam update
 if [ $is_msvc -eq 0 ]; then
     opam install depext-cygwinports depext ocamlfind
 else


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/commit/99024cada5cf60c9f479126ccfd582e320cd6d3b seems to be causing trouble, like

```
[ERROR] Bad checksum for
        C:/cygwin64/home/appveyor/.opam/packages.dev/ocp-build.1.99.19-beta/1.99.19-beta.tar.gz:
          - 83a32517f9e49119b200952f34e533d9 [expected result]
          - ac7000cfff5a0d94970050fa86f93667 [actual result]
        Metadata might be out of date, in this case run `opam update`.
```